### PR TITLE
fix criteria filter not working error

### DIFF
--- a/criteria.json
+++ b/criteria.json
@@ -1079,7 +1079,7 @@
 							"key": "117",
 							"label": "besondere funktionale Pr\u00e4gung",
 							"data": {
-								"columns": ["tN_besFu_p"],
+								"columns": ["tn_besfu_p"],
 								"filter": "prozent",
 								"value": 0
 							}


### PR DESCRIPTION
this error caused by column name in criteria.json file. system gives attribute names all lowercase but we were checking against actual column name.