### PR TITLE
feat: implement feature names and symbol layer for selected areas

### DIFF
--- a/src/components/ligfinder/LIGGeometryDrawnAreas.vue
+++ b/src/components/ligfinder/LIGGeometryDrawnAreas.vue
@@ -1,75 +1,84 @@
 <template>
-	<Card class="w-full">
-		<template #title>{{ $t('ligfinder.filter.geometry.drawn.title')}}</template>
-		<template #content>
-			<div class="w-full py-1" v-if="geometry.selectedDrawnGeometry.length>0">
-				<ChipWrapper v-for="(feature,index) in geometry.selectedDrawnGeometry" :key="feature.id" :label="`Area-${index}`" @remove="removeFromSelectedDrawnGeometries(feature)" removable severity="secondary"/>
-			</div>
-			<div class="w-full grid lg:grid-cols-1 2xl:grid-cols-3">
-				<div class="p-1" v-if="!drawTool.drawOnProgress && !drawTool.editOnProgress">
-					<Button class="w-full" size="small" @click="startDraw">{{ $t('ligfinder.filter.geometry.drawn.start')}}</Button>
-				</div>
-				<div class="p-1" v-if="(drawTool.drawOnProgress || drawTool.editOnProgress)">
-					<Button class="w-full" size="small"  :disabled="!(drawTool.drawOnProgress || drawTool.editOnProgress)" @click="drawTool.stopDrawMode">{{ $t('ligfinder.filter.geometry.drawn.cancel')}}</Button>
-				</div>
-				<div class="p-1" v-if="!drawTool.editOnProgress && drawTool.drawOnProgress">
-					<Button class="w-full" size="small" :disabled="!drawTool.drawOnProgress" @click="drawTool.editMode">{{ $t('ligfinder.filter.geometry.drawn.edit')}}</Button>
-				</div>
-				<div class="p-1" v-else>
-					<Button class="w-full" size="small" :disabled="!drawTool.editOnProgress" @click="startDraw">{{ $t('ligfinder.filter.geometry.drawn.continue')}}</Button>
-				</div>
-				<div class="p-1">
-					<Button class="w-full" size="small" :disabled="drawTool.drawMode !== 'polygon' " @click="addToDrawnArea">{{ $t('ligfinder.filter.geometry.drawn.add')}}</Button>
-				</div>
-			</div>
-		</template>
-	</Card>
+    <Card class="w-full">
+        <template #title>{{
+            $t("ligfinder.filter.geometry.drawn.title")
+            }}</template>
+        <template #content>
+            <div class="w-full py-1" v-if="geometry.selectedDrawnGeometry.length > 0">
+                <ChipWrapper v-for="feature in geometry.selectedDrawnGeometry" :key="feature.id"
+                    :label="feature.properties?.name" @remove="removeFromSelectedDrawnGeometries(feature)" removable
+                    severity="secondary" />
+            </div>
+            <div class="w-full grid lg:grid-cols-1 2xl:grid-cols-3">
+                <div class="p-1" v-if="!drawTool.drawOnProgress && !drawTool.editOnProgress">
+                    <Button class="w-full" size="small" @click="startDraw">{{
+                        $t("ligfinder.filter.geometry.drawn.start")
+                        }}</Button>
+                </div>
+                <div class="p-1" v-if="drawTool.drawOnProgress || drawTool.editOnProgress">
+                    <Button class="w-full" size="small"
+                        :disabled="!(drawTool.drawOnProgress || drawTool.editOnProgress)"
+                        @click="drawTool.stopDrawMode">{{ $t("ligfinder.filter.geometry.drawn.cancel") }}</Button>
+                </div>
+                <div class="p-1" v-if="!drawTool.editOnProgress && drawTool.drawOnProgress">
+                    <Button class="w-full" size="small" :disabled="!drawTool.drawOnProgress"
+                        @click="drawTool.editMode">{{ $t("ligfinder.filter.geometry.drawn.edit") }}</Button>
+                </div>
+                <div class="p-1" v-else>
+                    <Button class="w-full" size="small" :disabled="!drawTool.editOnProgress" @click="startDraw">{{
+                        $t("ligfinder.filter.geometry.drawn.continue") }}</Button>
+                </div>
+                <div class="p-1">
+                    <Button class="w-full" size="small" :disabled="drawTool.drawMode !== 'polygon'"
+                        @click="addToDrawnArea">{{ $t("ligfinder.filter.geometry.drawn.add") }}</Button>
+                </div>
+            </div>
+        </template>
+    </Card>
 </template>
 
 <script setup lang="ts">
-import Card from "primevue/card"
-import Button from "primevue/button"
-import ChipWrapper from "../base/ChipWrapper.vue"
-import { useDrawStore } from "../../store/maplibre/draw"
+import Card from "primevue/card";
+import Button from "primevue/button";
+import ChipWrapper from "../base/ChipWrapper.vue";
+import { useDrawStore } from "../../store/maplibre/draw";
 import { useGeometryStore } from "../../store/ligfinder/geometry";
-import { type Feature } from "geojson"
+import { type Feature } from "geojson";
 
-const geometry = useGeometryStore()
-const drawTool = useDrawStore()
-const drawMode = "polygon"
-function startDraw(): void{
-    drawTool.drawMode = drawMode
-    drawTool.initDrawMode()
+const geometry = useGeometryStore();
+const drawTool = useDrawStore();
+const drawMode = "polygon";
+function startDraw(): void {
+    drawTool.drawMode = drawMode;
+    drawTool.initDrawMode();
 }
-function addToDrawnArea(): void{
-    if (drawMode === "polygon"){
-        const drawnAreas = drawTool.getSnapshot()
+function addToDrawnArea(): void {
+    if (drawMode === "polygon") {
+        const drawnAreas = drawTool.getSnapshot();
         if (drawnAreas.length > 0) {
-            drawnAreas.forEach((feature)=> {
+            drawnAreas.forEach((feature) => {
                 try {
-                    geometry.addToSelectedDrawnGeometry(feature)
+                    geometry.addToSelectedDrawnGeometry(feature);
                 } catch (error) {
-                    console.error(error)
+                    console.error(error);
                 }
-            })
-            drawTool.stopDrawMode()
+            });
+            drawTool.stopDrawMode();
         } else {
-            console.error("there is no polygon to add")
+            console.error("there is no polygon to add");
         }
     } else {
-        console.error("You are trying to add invalid data type")
+        console.error("You are trying to add invalid data type");
     }
 }
 function removeFromSelectedDrawnGeometries(item: Feature): void {
     try {
-        geometry.removeFromSelectedDrawnGeometry(item)
-        geometry.updateSelectedAreasTempLayer()
+        geometry.removeFromSelectedDrawnGeometry(item);
+        geometry.updateSelectedAreasTempLayer();
     } catch (error) {
-        console.error(error)
+        console.error(error);
     }
 }
 </script>
 
-<style scoped>
-
-</style>
+<style scoped></style>

--- a/src/components/ligfinder/LIGGeometryIsochroneAreas.vue
+++ b/src/components/ligfinder/LIGGeometryIsochroneAreas.vue
@@ -1,46 +1,57 @@
 <template>
     <Card class="w-full isochrone-filter">
-        <template #title>{{ $t('ligfinder.filter.geometry.isochrone.title')}}</template>
+        <template #title>{{ $t('ligfinder.filter.geometry.isochrone.title') }}</template>
         <template #content>
             <div class="w-full py-1" v-if="geometry.selectedIsochrone.length > 0">
-                <ChipWrapper v-for="(_isochrone, index) in geometry.selectedIsochrone" :key="index" label="Isochrone"
-                    @remove="geometry.removeSelectedIsochrone" removable severity="secondary" />
+                <ChipWrapper v-for="(_isochrone, index) in geometry.selectedIsochrone" :key="index"
+                    :label="_isochrone.properties?.name || 'Isochrone'" @remove="geometry.removeSelectedIsochrone"
+                    removable severity="secondary" />
             </div>
-            <div class="w-full 2xl:flex 2xl:justify-between 2xl:grid-cols-none lg:grid lg:grid-cols-4 lg:gap-2 2xl:gap-0 p-1 ">
+            <div
+                class="w-full 2xl:flex 2xl:justify-between 2xl:grid-cols-none lg:grid lg:grid-cols-4 lg:gap-2 2xl:gap-0 p-1 ">
                 <div class="">
-                    <Button v-if="!geometry.selectionOnProgress" size="small" class="text-xs leading-4 2xl:grow-0 lg:w-full"
-                        @click="geometry.startCenterSelection">
+                    <Button v-if="!geometry.selectionOnProgress" size="small"
+                        class="text-xs leading-4 2xl:grow-0 lg:w-full" @click="geometry.startCenterSelection">
                         <template #icon>
                             <i class="material-icons">add_location_alt</i>
                         </template>
                     </Button>
-                    <Button v-else size="small" class="text-xs leading-4 2xl:grow-0" @click="geometry.cancelCenterSelection">
+                    <Button v-else size="small" class="text-xs leading-4 2xl:grow-0"
+                        @click="geometry.cancelCenterSelection">
                         <template #icon>
                             <i class="material-icons">wrong_location</i>
                         </template>
                     </Button>
                 </div>
                 <div class="lg:grid lg:grid-cols-subgrid lg:col-span-3 2xl:grid-cols-none">
-                    <SelectButton class="2xl:grow-0 lg:col-span-3 travel-mode flex" v-model="geometry.selectedTravelMode" :options="geometry.traveModeList"
-                        optionLabel="name" dataKey="value" aria-labelledby="custom">
+                    <SelectButton class="2xl:grow-0 lg:col-span-3 travel-mode flex"
+                        v-model="geometry.selectedTravelMode" :options="geometry.traveModeList" optionLabel="name"
+                        dataKey="value" aria-labelledby="custom">
                         <template #option="slotProps">
                             <i class="material-icons  mx-auto">{{ slotProps.option.icon }}</i>
                         </template>
                     </SelectButton>
                 </div>
                 <div class="lg:grid lg:grid-cols-subgrid lg:col-span-4 2xl:grid-cols-none">
-                    <InputNumber v-model="geometry.travelTime" input-class="grow lg:col-span-4" suffix="min" :min="0"></InputNumber>
+                    <InputNumber v-model="geometry.travelTime" input-class="grow lg:col-span-4" suffix="min" :min="0">
+                    </InputNumber>
                 </div>
                 <div class="lg:grid lg:grid-cols-subgrid lg:col-span-4 2xl:grid-cols-none">
-                    <Button size="small" class="lg:col-span-4 2xl:grow-0" :disabled="geometry.centerPoint === undefined" @click="geometry.createIsochrone">{{ $t('ligfinder.filter.geometry.isochrone.create')}}</Button>
+                    <Button size="small" class="lg:col-span-4 2xl:grow-0" :disabled="geometry.centerPoint === undefined"
+                        @click="geometry.createIsochrone">{{ $t('ligfinder.filter.geometry.isochrone.create')
+                        }}</Button>
                 </div>
             </div>
-            <div class="w-full grid grid-cols-4 pt-1" v-if="geometry.isochroneOnTheMap && geometry.isochroneOnTheMapData">
+            <div class="w-full grid grid-cols-4 pt-1"
+                v-if="geometry.isochroneOnTheMap && geometry.isochroneOnTheMapData">
                 <div class="p-1 lg:col-span-2">
-                    <Button class="w-full" size="small" @click="geometry.addSelectedIsochrone(geometry.isochroneOnTheMapData)">{{ $t('ligfinder.filter.geometry.isochrone.add')}}</Button>
+                    <Button class="w-full" size="small"
+                        @click="geometry.addSelectedIsochrone(geometry.isochroneOnTheMapData)">{{
+                            $t('ligfinder.filter.geometry.isochrone.add') }}</Button>
                 </div>
                 <div class="p-1 lg:col-span-2">
-                    <Button class="w-full" size="small" @click="geometry.cancelIsochroneSelection()">{{ $t('ligfinder.filter.geometry.isochrone.cancel')}}</Button>
+                    <Button class="w-full" size="small" @click="geometry.cancelIsochroneSelection()">{{
+                        $t('ligfinder.filter.geometry.isochrone.cancel') }}</Button>
                 </div>
             </div>
         </template>
@@ -59,7 +70,7 @@ const geometry = useGeometryStore()
 </script>
 
 <style scoped>
-@media screen and (max-width: 1440px){
+@media screen and (max-width: 1440px) {
     .isochrone-filter div.travel-mode:deep(div.h-full) {
         width: 100%;
     }

--- a/src/store/ligfinder/geometry.ts
+++ b/src/store/ligfinder/geometry.ts
@@ -1,130 +1,163 @@
-import { defineStore, acceptHMRUpdate } from "pinia"
-import { ref } from "vue"
-import { type FeatureCollection, type Feature, type Polygon, type MultiPolygon, type GeoJsonProperties } from "geojson"
-import { useMapStore } from "../maplibre/map"
-import { type MapMouseEvent, type Map } from "maplibre-gl"
-import { TerraDraw, TerraDrawMapLibreGLAdapter, TerraDrawPointMode } from "terra-draw"
-import { useDrawStore } from "../maplibre/draw"
-import intersect from "@turf/intersect"
+import { defineStore, acceptHMRUpdate } from "pinia";
+import { ref } from "vue";
+import {
+    type FeatureCollection,
+    type Feature,
+    type Polygon,
+    type MultiPolygon,
+    type GeoJsonProperties,
+} from "geojson";
+import { useMapStore } from "../maplibre/map";
+import { type MapMouseEvent, type Map } from "maplibre-gl";
+import {
+    TerraDraw,
+    TerraDrawMapLibreGLAdapter,
+    TerraDrawPointMode,
+} from "terra-draw";
+import { useDrawStore } from "../maplibre/draw";
+import intersect from "@turf/intersect";
 import { useI18n } from "vue-i18n";
 export interface IsochroneCenter {
-    lng: number,
-    lat: number
+    lng: number;
+    lat: number;
 }
 interface TravelMode {
-    name: string,
-    icon: string,
-    value: TravelModes
+    name: string;
+    icon: string;
+    value: TravelModes;
 }
 export interface AdministrativeBoundariesListItem {
-    id: number,
-    name: string,
-    "table_name": string,
+    id: number;
+    name: string;
+    table_name: string;
 }
 interface AdministrativeBoundariesAPIResponse {
-    data: AdministrativeBoundariesListItem[]
+    data: AdministrativeBoundariesListItem[];
 }
-export interface AdministrativeFeatureCollection extends AdministrativeBoundariesListItem {
-    data: FeatureCollection
+export interface AdministrativeFeatureCollection
+    extends AdministrativeBoundariesListItem {
+    data: FeatureCollection;
 }
-export interface AdministrativeFeature extends AdministrativeBoundariesListItem {
-    data: Feature
+export interface AdministrativeFeature
+    extends AdministrativeBoundariesListItem {
+    data: Feature;
 }
-export type TravelModes = "walk_network" | "drive_network" | "bike_network"
+export type TravelModes = "walk_network" | "drive_network" | "bike_network";
 export interface IsochroneForm {
-    time: number,
-    center: { "lng": number, "lat": number },
-    mode: TravelModes
+    time: number;
+    center: { lng: number; lat: number };
+    mode: TravelModes;
 }
-export interface ExtendedFeatureCollection extends FeatureCollection{
-    union: boolean,
-    tableName: string
+export interface ExtendedFeatureCollection extends FeatureCollection {
+    union: boolean;
+    tableName: string;
 }
 export interface UnionSelectionItem {
-    name: string,
-    value: "union"|"intersection"
+    name: string;
+    value: "union" | "intersection";
 }
 export interface GeometryFilterAPIResponse {
-    UUIDs: number[]
+    UUIDs: number[];
 }
 export const useGeometryStore = defineStore("geometry", () => {
     const { t } = useI18n();
-    const mapStore = useMapStore()
-    const drawTool = useDrawStore()
+    const mapStore = useMapStore();
+    const drawTool = useDrawStore();
     // ADMINISTRATIVE GEOMETRY
-    const activeAdministrativeArea = ref<AdministrativeBoundariesListItem | null>(null)
-    const administrativeBoundariesList = ref<AdministrativeBoundariesListItem[]>()
+    const activeAdministrativeArea = ref<AdministrativeBoundariesListItem | null>(
+        null
+    );
+    const administrativeBoundariesList =
+    ref<AdministrativeBoundariesListItem[]>();
     /**
-     * Fetches the list of administrative boundaries from the backend API.
-     * @returns A promise resolving to the list of administrative boundaries.
-     */
-    async function getAdministrativeBoundariesList(): Promise<AdministrativeBoundariesAPIResponse>{
-        const response = await fetch(`${import.meta.env.VITE_AGORA_API_BASE_URL}/administrative/list`,
+   * Fetches the list of administrative boundaries from the backend API.
+   * @returns A promise resolving to the list of administrative boundaries.
+   */
+    async function getAdministrativeBoundariesList(): Promise<AdministrativeBoundariesAPIResponse> {
+        const response = await fetch(
+            `${import.meta.env.VITE_AGORA_API_BASE_URL}/administrative/list`,
             {
                 method: "GET",
                 redirect: "follow",
                 headers: new Headers({
                     "Content-Type": "application/json",
-                })
-            })
-        return await response.json()
+                }),
+            }
+        );
+        return await response.json();
     }
-    const administrativeDataList = ref<AdministrativeFeatureCollection[]>([])
+    const administrativeDataList = ref<AdministrativeFeatureCollection[]>([]);
     /**
-     * Fetches the data for a specific administrative boundary by its ID.
-     * @param id - The ID of the administrative boundary.
-     * @returns A promise resolving to the FeatureCollection of the boundary.
-     */
-    async function getAdministrativeBoundaryData(id: number): Promise<FeatureCollection> {
-        const response = await fetch(`${import.meta.env.VITE_AGORA_API_BASE_URL}/administrative/data/${id}`,
+   * Fetches the data for a specific administrative boundary by its ID.
+   * @param id - The ID of the administrative boundary.
+   * @returns A promise resolving to the FeatureCollection of the boundary.
+   */
+    async function getAdministrativeBoundaryData(
+        id: number
+    ): Promise<FeatureCollection> {
+        const response = await fetch(
+            `${import.meta.env.VITE_AGORA_API_BASE_URL}/administrative/data/${id}`,
             {
                 method: "GET",
                 redirect: "follow",
                 headers: new Headers({
                     "Content-Type": "application/json",
-                })
-            })
-        return await response.json()
+                }),
+            }
+        );
+        return await response.json();
     }
-    const selectedAdministrativeFeaturesList = ref<AdministrativeFeature[]>([])
+    const selectedAdministrativeFeaturesList = ref<AdministrativeFeature[]>([]);
     /**
-     * Adds an administrative feature to the selected administrative features list.
-     * @param item - The administrative feature to add to the list.
-     * @returns A boolean indicating whether the feature was successfully added (`true`) or not (`false`).
-     */
-    function addToselectedAdministrativeFeaturesList(item: AdministrativeFeature): boolean {
-        console.log(item)
-        if (selectedAdministrativeFeaturesList.value.length>0){
-            let alreadySelected = false
+   * Adds an administrative feature to the selected administrative features list.
+   * @param item - The administrative feature to add to the list.
+   * @returns A boolean indicating whether the feature was successfully added (`true`) or not (`false`).
+   */
+    function addToselectedAdministrativeFeaturesList(
+        item: AdministrativeFeature
+    ): boolean {
+        console.log(item);
+        if (selectedAdministrativeFeaturesList.value.length > 0) {
+            let alreadySelected = false;
             selectedAdministrativeFeaturesList.value.forEach((feature) => {
-                if ((feature.table_name === item.table_name) && (feature.data.properties!.gid === item.data.properties!.gid)){
-                    alreadySelected = true
+                if (
+                    feature.table_name === item.table_name &&
+          feature.data.properties!.gid === item.data.properties!.gid
+                ) {
+                    alreadySelected = true;
                 }
-            })
-            if (alreadySelected){
-                throw new Error(t("ligfinder.filter.geometry.errors.pinia.featureAlreadySelected"))
+            });
+            if (alreadySelected) {
+                throw new Error(
+                    t("ligfinder.filter.geometry.errors.pinia.featureAlreadySelected")
+                );
             } else {
-                selectedAdministrativeFeaturesList.value.push(item)
-                updateSelectedAreasTempLayer()
-                return true
+                selectedAdministrativeFeaturesList.value.push(item);
+                updateSelectedAreasTempLayer();
+                return true;
             }
         } else {
-            selectedAdministrativeFeaturesList.value.push(item)
-            updateSelectedAreasTempLayer()
-            return true
+            selectedAdministrativeFeaturesList.value.push(item);
+            updateSelectedAreasTempLayer();
+            return true;
         }
     }
     /**
-     * Removes an administrative feature from the selected administrative features list.
-     * @param item - The administrative feature to remove from the list.
-     * @returns A boolean indicating whether the feature was successfully removed (`true`) or not (`false`).
-     */
-    function removeFromSelectedAdministrativeFeaturesList(item: AdministrativeFeature): boolean {
-        const index = selectedAdministrativeFeaturesList.value.findIndex(feature =>
-            feature.table_name === item.table_name && feature.data.properties!.gid === item.data.properties!.gid)
+   * Removes an administrative feature from the selected administrative features list.
+   * @param item - The administrative feature to remove from the list.
+   * @returns A boolean indicating whether the feature was successfully removed (`true`) or not (`false`).
+   */
+    function removeFromSelectedAdministrativeFeaturesList(
+        item: AdministrativeFeature
+    ): boolean {
+        const index = selectedAdministrativeFeaturesList.value.findIndex(
+            (feature) =>
+                feature.table_name === item.table_name &&
+        feature.data.properties!.gid === item.data.properties!.gid
+        );
         if (index !== -1) {
             selectedAdministrativeFeaturesList.value.splice(index, 1);
-            updateSelectedAreasTempLayer()
+            updateSelectedAreasTempLayer();
             return true;
         } else {
             return false;
@@ -132,57 +165,94 @@ export const useGeometryStore = defineStore("geometry", () => {
     }
 
     /**
-     * Changes the active administrative area layer on the map to reflect the current selection.
-     */
-    function changeActiveAdminLayerOnMap(): void{
+   * Changes the active administrative area layer on the map to reflect the current selection.
+   */
+    function changeActiveAdminLayerOnMap(): void {
         if (activeAdministrativeArea.value !== null) {
-            const activeData = administrativeDataList.value.filter((item) => { return item.table_name === activeAdministrativeArea.value!.table_name })
-            updateActiveAdminLayer(activeData[0].data)
+            const activeData = administrativeDataList.value.filter((item) => {
+                return item.table_name === activeAdministrativeArea.value!.table_name;
+            });
+            updateActiveAdminLayer(activeData[0].data);
         } else {
             const emptyGeojson: FeatureCollection = {
                 type: "FeatureCollection",
-                features:[]
-            }
-            updateActiveAdminLayer(emptyGeojson)
+                features: [],
+            };
+            updateActiveAdminLayer(emptyGeojson);
         }
     }
     // DRAWN GEOMETRY
-    const selectedDrawnGeometry = ref<Feature[]>([])
+    const selectedDrawnGeometry = ref<Feature[]>([]);
     /**
-     * Adds an administrative feature to the selected administrative features list.
-     * @param item - The feature to add to the list.
-     * @returns A boolean indicating whether the feature was successfully added (`true`) or not (`false`).
-     */
+   * Adds an administrative feature to the selected administrative features list.
+   * @param item - The feature to add to the list.
+   * @returns A boolean indicating whether the feature was successfully added (`true`) or not (`false`).
+   */
+    /**
+   * Adds an administrative feature to the selected administrative features list.
+   * @param item - The feature to add to the list.
+   * @returns A boolean indicating whether the feature was successfully added (`true`) or not (`false`).
+   */
     function addToSelectedDrawnGeometry(item: Feature): boolean {
-        if (selectedDrawnGeometry.value.length > 0){
-            let alreadySelected = false
+        if (selectedDrawnGeometry.value.length > 0) {
+            let alreadySelected = false;
             selectedDrawnGeometry.value.forEach((feature) => {
-                if (feature.id === item.id){
-                    alreadySelected = true
+                if (feature.id === item.id) {
+                    alreadySelected = true;
                 }
-            })
-            if (alreadySelected){
-                throw new Error(t("ligfinder.filter.geometry.errors.pinia.featureAlreadySelected"))
+            });
+            if (alreadySelected) {
+                throw new Error(
+                    t("ligfinder.filter.geometry.errors.pinia.featureAlreadySelected")
+                );
             } else {
-                selectedDrawnGeometry.value.push(item)
-                updateSelectedAreasTempLayer()
-                console.log(selectedDrawnGeometry.value)
-                return true
+                // Generate unique name
+                let counter = 1;
+                const baseName = "Drawn Area";
+                let newName = `${baseName} ${counter}`;
+                const existingNames = selectedDrawnGeometry.value.map(
+                    (f) => f.properties?.name
+                );
+
+                while (existingNames.includes(newName)) {
+                    counter++;
+                    newName = `${baseName} ${counter}`;
+                }
+
+                if (item.properties != null) {
+                    item.properties.name = newName;
+                } else {
+                    item.properties = { name: newName };
+                }
+
+                selectedDrawnGeometry.value.push(item);
+                updateSelectedAreasTempLayer();
+                return true;
             }
         } else {
-            selectedDrawnGeometry.value.push(item)
-            updateSelectedAreasTempLayer()
-            console.log(selectedDrawnGeometry.value)
+            // Generate unique name (first item)
+            const newName = "Drawn Area 1";
+            if (item.properties != null) {
+                item.properties.name = newName;
+            } else {
+                item.properties = { name: newName };
+            }
+
+            selectedDrawnGeometry.value.push(item);
+            updateSelectedAreasTempLayer();
+            console.log(selectedDrawnGeometry.value);
         }
-        return true
+        return true;
     }
     /**
-     * Removes an administrative feature from the selected administrative features list.
-     * @param item - The feature to remove from the list.
-     * @returns A boolean indicating whether the feature was successfully removed (`true`) or not (`false`).
-     */
+   * Removes an administrative feature from the selected administrative features list.
+   * @param item - The feature to remove from the list.
+   * @returns A boolean indicating whether the feature was successfully removed (`true`) or not (`false`).
+   */
     function removeFromSelectedDrawnGeometry(item: Feature): boolean {
-        const index = selectedDrawnGeometry.value.findIndex(feature => feature.id === item.id)
+        const index = selectedDrawnGeometry.value.findIndex(
+            (feature) => feature.id === item.id
+        );
         if (index !== -1) {
             selectedDrawnGeometry.value.splice(index, 1);
             return true;
@@ -191,362 +261,610 @@ export const useGeometryStore = defineStore("geometry", () => {
         }
     }
     // ISOCHRONE GEOMETRY
-    const selectionOnProgress = ref<boolean>(false)
-    const traveModeList = ref<TravelMode[]>([{ name: "walk", icon: "directions_walk", value: "walk_network" }, { name: "bike", icon: "directions_bike", value: "bike_network" }, { name: "drive", icon: "directions_car", value: "drive_network" }])
-    const selectedTravelMode = ref<TravelMode>({ name: "walk", icon: "pi-user", value: "walk_network" })
-    const centerPoint = ref<IsochroneCenter>()
-    const travelTime = ref<number>(0)
+    const selectionOnProgress = ref<boolean>(false);
+    const traveModeList = ref<TravelMode[]>([
+        { name: "walk", icon: "directions_walk", value: "walk_network" },
+        { name: "bike", icon: "directions_bike", value: "bike_network" },
+        { name: "drive", icon: "directions_car", value: "drive_network" },
+    ]);
+    const selectedTravelMode = ref<TravelMode>({
+        name: "walk",
+        icon: "pi-user",
+        value: "walk_network",
+    });
+    const centerPoint = ref<IsochroneCenter>();
+    const travelTime = ref<number>(0);
     const centerSelectDrawer = new TerraDraw({
-        adapter: new TerraDrawMapLibreGLAdapter({ map: mapStore.map as unknown as Map }),
+        adapter: new TerraDrawMapLibreGLAdapter({
+            map: mapStore.map as unknown as Map,
+        }),
         modes: [
             new TerraDrawPointMode({
                 styles: {
                     pointColor: "#AA4545",
-                    pointWidth: 12
-                }
-            })
-        ]
-    })
+                    pointWidth: 12,
+                },
+            }),
+        ],
+    });
     /**
-     * Creates an isochrone based on the selected center point and travel time.
-     */
+   * Creates an isochrone based on the selected center point and travel time.
+   */
     function createIsochrone(): void {
         if (centerPoint.value === undefined) {
-            throw new Error(t("ligfinder.filter.geometry.errors.pinia.noCenterPoint"))
+            throw new Error(
+                t("ligfinder.filter.geometry.errors.pinia.noCenterPoint")
+            );
         }
         if (!(travelTime.value > 0)) {
-            throw new Error(t("ligfinder.filter.geometry.errors.pinia.invalidTravelTime"))
+            throw new Error(
+                t("ligfinder.filter.geometry.errors.pinia.invalidTravelTime")
+            );
         }
-        if (centerPoint.value?.lat !== undefined && centerPoint.value.lng !== undefined) {
+        if (
+            centerPoint.value?.lat !== undefined &&
+      centerPoint.value.lng !== undefined
+        ) {
             const isochroneInfo: IsochroneForm = {
                 time: travelTime.value,
                 center: { ...centerPoint.value },
-                mode: selectedTravelMode.value.value
-            }
-            getIsochrone(isochroneInfo).then((response) => {
-                addIsochroneSource(response)
-            }).catch((error => { console.error(error); })).finally(() => {
-                cancelCenterSelection()
-            })
+                mode: selectedTravelMode.value.value,
+            };
+            getIsochrone(isochroneInfo)
+                .then((response) => {
+                    addIsochroneSource(response);
+                })
+                .catch((error) => {
+                    console.error(error);
+                })
+                .finally(() => {
+                    cancelCenterSelection();
+                });
         }
     }
     /**
-     * Starts the selection process for the isochrone center point.
-     */
+   * Starts the selection process for the isochrone center point.
+   */
     function startCenterSelection(): void {
-        selectionOnProgress.value = true
-        drawTool.stopDrawMode()
-        centerSelectDrawer.start()
-        centerSelectDrawer.setMode("point")
-        centerSelectDrawer.on("change", centerSelector)
+        selectionOnProgress.value = true;
+        drawTool.stopDrawMode();
+        centerSelectDrawer.start();
+        centerSelectDrawer.setMode("point");
+        centerSelectDrawer.on("change", centerSelector);
     }
     /**
-     * Cancels the selection process for the isochrone center point.
-     */
+   * Cancels the selection process for the isochrone center point.
+   */
     function cancelCenterSelection(): void {
-        console.log("canceling center selection")
-        selectionOnProgress.value = false
-        centerSelectDrawer.setMode("static")
-        centerSelectDrawer.off("change", centerSelector)
-        centerSelectDrawer.stop()
-        centerPoint.value = undefined
-        travelTime.value = 0
+        console.log("canceling center selection");
+        selectionOnProgress.value = false;
+        centerSelectDrawer.setMode("static");
+        centerSelectDrawer.off("change", centerSelector);
+        centerSelectDrawer.stop();
+        centerPoint.value = undefined;
+        travelTime.value = 0;
     }
     /**
-     * Handles the selection of the center point for the isochrone.
-     */
+   * Handles the selection of the center point for the isochrone.
+   */
     function centerSelector(): void {
-        const snap = centerSelectDrawer.getSnapshot()
+        const snap = centerSelectDrawer.getSnapshot();
         if (snap.length > 1) {
-            centerSelectDrawer.removeFeatures([snap[0].id ?? ""])
+            centerSelectDrawer.removeFeatures([snap[0].id ?? ""]);
         }
-        centerPoint.value = { ...{ lng: snap[0].geometry.coordinates[0] as number, lat: snap[0].geometry.coordinates[1] as number } }
+        centerPoint.value = {
+            ...{
+                lng: snap[0].geometry.coordinates[0] as number,
+                lat: snap[0].geometry.coordinates[1] as number,
+            },
+        };
     }
-    const isochroneOnTheMap = ref<boolean>(false)
-    const isochroneOnTheMapData = ref<FeatureCollection>()
+    const isochroneOnTheMap = ref<boolean>(false);
+    const isochroneOnTheMapData = ref<FeatureCollection>();
     /**
-     * Adds the isochrone source to the map and updates the state.
-     * @param src - The FeatureCollection representing the isochrone.
-     */
+   * Adds the isochrone source to the map and updates the state.
+   * @param src - The FeatureCollection representing the isochrone.
+   */
     function addIsochroneSource(src: FeatureCollection): void {
-        const layerStyle = { paint: { "fill-color": "#abcdef", "fill-opacity": 0.6 } }
-        mapStore.addMapDataSource("geojson", "isochrone-temp-source", false, undefined, undefined, src).then(() => {
-            mapStore.addMapLayer("geojson", "isochrone-temp-source", "fill", layerStyle, undefined, undefined, src, undefined, undefined, undefined, false).then(() => {
-                isochroneOnTheMap.value = true
-                isochroneOnTheMapData.value = src
-            }).catch((error) => { console.log(error) })
-        }).catch((error) => { console.error(error) })
+        const layerStyle = {
+            paint: { "fill-color": "#abcdef", "fill-opacity": 0.6 },
+        };
+        mapStore
+            .addMapDataSource(
+                "geojson",
+                "isochrone-temp-source",
+                false,
+                undefined,
+                undefined,
+                src
+            )
+            .then(() => {
+                mapStore
+                    .addMapLayer(
+                        "geojson",
+                        "isochrone-temp-source",
+                        "fill",
+                        layerStyle,
+                        undefined,
+                        undefined,
+                        src,
+                        undefined,
+                        undefined,
+                        undefined,
+                        false
+                    )
+                    .then(() => {
+                        isochroneOnTheMap.value = true;
+                        isochroneOnTheMapData.value = src;
+                    })
+                    .catch((error) => {
+                        console.log(error);
+                    });
+            })
+            .catch((error) => {
+                console.error(error);
+            });
     }
     /**
-     * Adds the selected isochrone to the state and cancels the selection process.
-     * @param data - The FeatureCollection representing the selected isochrone.
-     */
+   * Adds the selected isochrone to the state and cancels the selection process.
+   * @param data - The FeatureCollection representing the selected isochrone.
+   */
     function addSelectedIsochrone(data: FeatureCollection): void {
-        const applied = addToSelectedIsochrone(data)
+        const applied = addToSelectedIsochrone(data);
         if (applied) {
-            cancelIsochroneSelection()
+            cancelIsochroneSelection();
         }
     }
     /**
-     * Cancels the isochrone selection process and removes temporary layers from the map.
-     */
+   * Cancels the isochrone selection process and removes temporary layers from the map.
+   */
     function cancelIsochroneSelection(): void {
-        console.log("canceling isochrone selection")
-        console.log(centerSelectDrawer.enabled)
-        if (mapStore.map.getLayer("isochrone-temp-source") !== undefined){
-            mapStore.map.removeLayer("isochrone-temp-source")
-            mapStore.removeFromLayerList("isochrone-temp-source")
-            mapStore.map.removeSource("isochrone-temp-source")
-            isochroneOnTheMap.value = false
+        console.log("canceling isochrone selection");
+        console.log(centerSelectDrawer.enabled);
+        if (mapStore.map.getLayer("isochrone-temp-source") !== undefined) {
+            mapStore.map.removeLayer("isochrone-temp-source");
+            mapStore.removeFromLayerList("isochrone-temp-source");
+            mapStore.map.removeSource("isochrone-temp-source");
+            isochroneOnTheMap.value = false;
         }
-        if (centerSelectDrawer.enabled){
-            cancelCenterSelection()
+        if (centerSelectDrawer.enabled) {
+            cancelCenterSelection();
         }
     }
     /**
-     * Fetches an isochrone from the backend API based on the provided form data.
-     * @param data - The form data for the isochrone request.
-     * @returns A promise resolving to the FeatureCollection representing the isochrone.
-     */
-    async function getIsochrone(data: IsochroneForm): Promise<FeatureCollection>{
-        const response = await fetch(`${import.meta.env.VITE_AGORA_API_BASE_URL}/geometry/isochrone`,
+   * Fetches an isochrone from the backend API based on the provided form data.
+   * @param data - The form data for the isochrone request.
+   * @returns A promise resolving to the FeatureCollection representing the isochrone.
+   */
+    async function getIsochrone(data: IsochroneForm): Promise<FeatureCollection> {
+        const response = await fetch(
+            `${import.meta.env.VITE_AGORA_API_BASE_URL}/geometry/isochrone`,
             {
                 method: "POST",
                 redirect: "follow",
                 headers: new Headers({
                     "Content-Type": "application/json",
                 }),
-                body: JSON.stringify(data)
-            })
-        return await response.json()
+                body: JSON.stringify(data),
+            }
+        );
+        const result = await response.json();
+        result.features.forEach((feature: Feature) => {
+            if (feature.properties === null) feature.properties = {};
+            feature.properties.time = data.time;
+            feature.properties.mode = data.mode;
+        });
+        return result;
     }
-    const selectedIsochrone = ref<Feature[]>([])
+    const selectedIsochrone = ref<Feature[]>([]);
     /**
-     * Adds a FeatureCollection to the selected isochrone state and updates the map.
-     * @param item - The FeatureCollection to add.
-     * @returns True if the operation was successful.
-     */
+   * Adds a FeatureCollection to the selected isochrone state and updates the map.
+   * @param item - The FeatureCollection to add.
+   * @returns True if the operation was successful.
+   */
     function addToSelectedIsochrone(item: FeatureCollection): boolean {
-        const itemList: Feature[] = []
+        const itemList: Feature[] = [];
         item.features.forEach((feature) => {
-            itemList.push(feature)
-        })
-        selectedIsochrone.value = itemList
-        updateSelectedAreasTempLayer()
-        return true
+            // Ensure properties exists and set name immediately to capture current travelTime/Mode
+            if (feature.properties === null) feature.properties = {};
+            if (
+                feature.properties.name === null ||
+        feature.properties.name === undefined
+            ) {
+                const time = (feature.properties.time as number) ?? travelTime.value;
+                const modeValue =
+          (feature.properties.mode as string) ?? selectedTravelMode.value.value;
+
+                const modeObj = traveModeList.value.find((m) => m.value === modeValue);
+                const modeName = modeObj !== undefined ? modeObj.name : "unknown";
+
+                const timeLabel = `${Math.round(time)} min`;
+                feature.properties.name = `Isochrone (${modeName} - ${timeLabel})`;
+            }
+            itemList.push(feature);
+        });
+        selectedIsochrone.value = itemList;
+        updateSelectedAreasTempLayer();
+        return true;
     }
     /**
-     * Removes the selected isochrone from the state and updates the map.
-     */
-    function removeSelectedIsochrone(): void{
-        selectedIsochrone.value = []
-        updateSelectedAreasTempLayer()
+   * Removes the selected isochrone from the state and updates the map.
+   */
+    function removeSelectedIsochrone(): void {
+        selectedIsochrone.value = [];
+        updateSelectedAreasTempLayer();
     }
     // GEOMETRY FILTER
     /**
-     * Creates a geometry filter based on the currently selected geometries and sends it to the backend API.
-     * @returns A promise resolving to the geometry filter API response.
-     * @throws Error if the selected geometries do not intersect or the fetch fails.
-     */
+   * Creates a geometry filter based on the currently selected geometries and sends it to the backend API.
+   * @returns A promise resolving to the geometry filter API response.
+   * @throws Error if the selected geometries do not intersect or the fetch fails.
+   */
     async function createGeometryFilter(): Promise<GeometryFilterAPIResponse> {
-        const featureCollection: ExtendedFeatureCollection = createSelectedGeometryGeoJSON(true) as ExtendedFeatureCollection
-        if (featureCollection.features.length===0){
-            return await Promise.resolve({ UUIDs:[] })
+        const featureCollection: ExtendedFeatureCollection =
+      createSelectedGeometryGeoJSON(true) as ExtendedFeatureCollection;
+        if (featureCollection.features.length === 0) {
+            return await Promise.resolve({ UUIDs: [] });
         }
-        if (!featureCollection.union){
-            const hasValidIntersection = intersect({ type:"FeatureCollection", features:featureCollection.features as Array<Feature<Polygon | MultiPolygon, GeoJsonProperties>> }) !== null
-            if (!hasValidIntersection){
-                throw new Error(t("ligfinder.filter.geometry.errors.pinia.invalidIntersection"))
+        if (!featureCollection.union) {
+            const hasValidIntersection =
+        intersect({
+            type: "FeatureCollection",
+            features: featureCollection.features as Array<
+            Feature<Polygon | MultiPolygon, GeoJsonProperties>
+            >,
+        }) !== null;
+            if (!hasValidIntersection) {
+                throw new Error(
+                    t("ligfinder.filter.geometry.errors.pinia.invalidIntersection")
+                );
             }
         }
-        const response = await fetch(`${import.meta.env.VITE_AGORA_API_BASE_URL}/geometry/filter`,
+        const response = await fetch(
+            `${import.meta.env.VITE_AGORA_API_BASE_URL}/geometry/filter`,
             {
                 method: "POST",
                 redirect: "follow",
                 headers: new Headers({
                     "Content-Type": "application/json",
                 }),
-                body: JSON.stringify(featureCollection)
-            })
+                body: JSON.stringify(featureCollection),
+            }
+        );
         if (!response.ok) {
             // Handle non-2xx responses
             const errorText = await response.text(); // Using text() as the response might not always be JSON
-            throw new Error(`Failed to fetch geometry filter: ${response.status} ${errorText}`);
+            throw new Error(
+                `Failed to fetch geometry filter: ${response.status} ${errorText}`
+            );
         }
-        return await response.json()
+        return await response.json();
     }
     /**
-     * Creates a MapLibre GL filter expression for the given list of UUIDs.
-     * @param idList - The list of UUIDs to include in the filter.
-     * @returns An array representing the filter expression.
-     */
-    function createGeometryFilterExpression(idList: number[]): any[]{
-        if (idList.length>0){
-            return ["in", ["get", "UUID"], ["literal", idList]]
+   * Creates a MapLibre GL filter expression for the given list of UUIDs.
+   * @param idList - The list of UUIDs to include in the filter.
+   * @returns An array representing the filter expression.
+   */
+    function createGeometryFilterExpression(idList: number[]): any[] {
+        if (idList.length > 0) {
+            return ["in", ["get", "UUID"], ["literal", idList]];
         } else {
-            return []
+            return [];
         }
     }
-    const geometryFilterResult = ref<string[]>([])
+    const geometryFilterResult = ref<string[]>([]);
     /**
-     * Adds a list of geometry filter results to the state and updates the map.
-     * @param item - The list of geometry filter result strings.
-     */
+   * Adds a list of geometry filter results to the state and updates the map.
+   * @param item - The list of geometry filter result strings.
+   */
     function addToGeometryFilterResult(item: string[]): void {
-        geometryFilterResult.value = item
-        updateSelectedAreasTempLayer()
+        geometryFilterResult.value = item;
+        updateSelectedAreasTempLayer();
     }
     /**
-     * Clears the geometry filter results from the state and updates the map.
-     */
-    function clearGeometryFilterResult(): void{
-        geometryFilterResult.value = []
-        updateSelectedAreasTempLayer()
+   * Clears the geometry filter results from the state and updates the map.
+   */
+    function clearGeometryFilterResult(): void {
+        geometryFilterResult.value = [];
+        updateSelectedAreasTempLayer();
     }
-    const unionSelectionList = ref<UnionSelectionItem[]>([{ name:"union", value:"union" }, { name:"intersection", value:"intersection" }])
-    const isUnion = ref<UnionSelectionItem>({ name:"union", value:"union" })
+    const unionSelectionList = ref<UnionSelectionItem[]>([
+        { name: "union", value: "union" },
+        { name: "intersection", value: "intersection" },
+    ]);
+    const isUnion = ref<UnionSelectionItem>({ name: "union", value: "union" });
     /**
-     * Creates a GeoJSON FeatureCollection from all selected features.
-     * @param isExtended - Whether to create an extended feature collection with union and tableName properties.
-     * @returns The created FeatureCollection or ExtendedFeatureCollection.
-     */
-    function createSelectedGeometryGeoJSON(isExtended: boolean): ExtendedFeatureCollection|FeatureCollection{
-        const allSelectedFeatures: Feature[] = []
+   * Creates a GeoJSON FeatureCollection from all selected features.
+   * @param isExtended - Whether to create an extended feature collection with union and tableName properties.
+   * @returns The created FeatureCollection or ExtendedFeatureCollection.
+   */
+    function createSelectedGeometryGeoJSON(
+        isExtended: boolean
+    ): ExtendedFeatureCollection | FeatureCollection {
+        const allSelectedFeatures: Feature[] = [];
         selectedAdministrativeFeaturesList.value.forEach((feature) => {
-            allSelectedFeatures.push(feature.data)
-        })
+            // Ensure properties exists and set name
+            if (feature.data.properties === null) feature.data.properties = {};
+            if (
+                feature.data.properties.name === null ||
+        feature.data.properties.name === undefined
+            ) {
+                feature.data.properties.name = feature.name;
+            }
+
+            allSelectedFeatures.push(feature.data);
+        });
         selectedDrawnGeometry.value.forEach((feature) => {
-            allSelectedFeatures.push(feature)
-        })
+            // Name is already set in addToSelectedDrawnGeometry, but fallback just in case
+            if (feature.properties === null) feature.properties = {};
+            if (
+                feature.properties.name === null ||
+        feature.properties.name === undefined
+            ) {
+                feature.properties.name = "Drawn Area";
+            }
+
+            allSelectedFeatures.push(feature);
+        });
         selectedIsochrone.value.forEach((feature) => {
-            allSelectedFeatures.push(feature)
-        })
-        if (isExtended){
+            // Name should be set in addToSelectedIsochrone
+            if (feature.properties === null) feature.properties = {};
+            if (
+                feature.properties.name === null ||
+        feature.properties.name === undefined
+            ) {
+                feature.properties.name = "Isochrone (Unknown)";
+            }
+
+            allSelectedFeatures.push(feature);
+        });
+        if (isExtended) {
             const featureCollection: ExtendedFeatureCollection = {
                 type: "FeatureCollection",
                 features: allSelectedFeatures,
-                union:isUnion.value.value === "union",
-                tableName:import.meta.env.VITE_PARCEL_DATASET_LAYERNAME
-            }
-            return featureCollection
+                union: isUnion.value.value === "union",
+                tableName: import.meta.env.VITE_PARCEL_DATASET_LAYERNAME,
+            };
+            return featureCollection;
         } else {
             const featureCollection: FeatureCollection = {
                 type: "FeatureCollection",
-                features: allSelectedFeatures
-            }
-            return featureCollection
+                features: allSelectedFeatures,
+            };
+            return featureCollection;
         }
     }
     /**
-     * Creates a temporary layer on the map to display the selected areas.
-     */
-    function createSelectedAreasTempLayer(): void{
-        const features: FeatureCollection = createSelectedGeometryGeoJSON(false) as FeatureCollection
+   * Creates a temporary layer on the map to display the selected areas.
+   */
+    function createSelectedAreasTempLayer(): void {
+        const features: FeatureCollection = createSelectedGeometryGeoJSON(
+            false
+        ) as FeatureCollection;
         const layerStyle: Record<string, any> = {
-            paint:{
+            paint: {
                 "fill-color": "#FF0000",
                 "fill-opacity": 0.05,
-                "fill-outline-color": "#000000"
-            }
-        }
-        mapStore.addMapDataSource("geojson", "selectedAreasTempLayer", false, undefined, undefined, features).then(()=>{
-            mapStore.addMapLayer("geojson", "selectedAreasTempLayer", "fill", layerStyle, undefined, undefined, features, false, undefined, undefined, false).then(()=>{}).catch((error)=>{ console.error(error) })
-        }).catch((error)=>{ console.error(error) })
+                "fill-outline-color": "#000000",
+            },
+        };
+        const labelStyle: Record<string, any> = {
+            layout: {
+                "text-field": ["get", "name"],
+                "text-font": ["Open Sans Bold", "Arial Unicode MS Bold"],
+                "text-size": 12,
+                "text-offset": [0, 0.6],
+                "text-anchor": "top",
+            },
+            paint: {
+                "text-halo-color": "#ffffff",
+                "text-halo-width": 1,
+            },
+        };
+
+        mapStore
+            .addMapDataSource(
+                "geojson",
+                "selectedAreasTempLayer",
+                false,
+                undefined,
+                undefined,
+                features
+            )
+            .then(() => {
+                mapStore
+                    .addMapLayer(
+                        "geojson",
+                        "selectedAreasTempLayer",
+                        "fill",
+                        layerStyle,
+                        undefined,
+                        undefined,
+                        features,
+                        false,
+                        undefined,
+                        undefined,
+                        false
+                    )
+                    .then(() => {})
+                    .catch((error) => {
+                        console.error(error);
+                    });
+
+                // Add symbol layer for labels
+                mapStore
+                    .addMapLayer(
+                        "geojson",
+                        "selectedAreasLabels",
+                        "symbol",
+                        labelStyle,
+                        undefined,
+                        undefined,
+                        features,
+                        false,
+                        undefined,
+                        "selectedAreasTempLayer",
+                        false
+                    )
+                    .then(() => {})
+                    .catch((error) => {
+                        console.error(error);
+                    });
+            })
+            .catch((error) => {
+                console.error(error);
+            });
     }
     /**
-     * Updates the temporary layer on the map to reflect the current selection of areas.
-     */
-    function updateSelectedAreasTempLayer(): void{
-        // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
-        if (!(mapStore.map.getSource("selectedAreasTempLayer"))){
-            createSelectedAreasTempLayer()
+   * Updates the temporary layer on the map to reflect the current selection of areas.
+   */
+    function updateSelectedAreasTempLayer(): void {
+    // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
+        if (!mapStore.map.getSource("selectedAreasTempLayer")) {
+            createSelectedAreasTempLayer();
         }
-        mapStore.map.getSource("selectedAreasTempLayer").setData(createSelectedGeometryGeoJSON(false) as FeatureCollection)
+        mapStore.map
+            .getSource("selectedAreasTempLayer")
+            .setData(createSelectedGeometryGeoJSON(false) as FeatureCollection);
     }
     /**
-     * Deletes the temporary layer displaying selected areas from the map.
-     */
-    function deleteSelectedAreasTempLayer(): void{
-        mapStore.map.removeLayer("selectedAreasTempLayer")
-        mapStore.map.removeSource("selectedAreasTempLayer")
-        mapStore.removeFromLayerList("selectedAreasTempLayer")
+   * Deletes the temporary layer displaying selected areas from the map.
+   */
+    function deleteSelectedAreasTempLayer(): void {
+        mapStore.map.removeLayer("selectedAreasLabels");
+        mapStore.map.removeLayer("selectedAreasTempLayer");
+        mapStore.map.removeSource("selectedAreasTempLayer");
+        mapStore.removeFromLayerList("selectedAreasTempLayer");
+    // No need to remove selectedAreasLabels from layer list as we didn't add it there (or we rely on it being hidden/ephemeral)
+    // If mapStore.addMapLayer adds it to the list, we might want to remove it.
+    // Based on addMapLayer call above, showOnLayerList defaults to true if not passed, but we passed 'false' as 8th arg for fill layer.
+    // For symbol layer we passed false as 8th arg (isFilterLayer) and then undefined, "selectedAreasTempLayer", false.
+    // So showOnLayerList is false. Thus no need to removeFromLayerList for labels.
     }
     // active administrative area layer operations
     /**
-     * Handles click events on the active administrative area layer.
-     * @param e - The map mouse event.
-     */
-    function adminAreaClickEventHandler(e: any): void{
-        (e as MapMouseEvent).originalEvent.stopPropagation()
-        console.log("event", e as Event)
-        console.log(mapStore.map.getLayersOrder())
-        const activeDataFeaturesList = administrativeDataList.value.filter((item) => { return item.table_name === activeAdministrativeArea.value?.table_name })
-        const clickedFeatureGID = e.features[0].properties.gid
+   * Handles click events on the active administrative area layer.
+   * @param e - The map mouse event.
+   */
+    function adminAreaClickEventHandler(e: any): void {
+        (e as MapMouseEvent).originalEvent.stopPropagation();
+        console.log("event", e as Event);
+        console.log(mapStore.map.getLayersOrder());
+        const activeDataFeaturesList = administrativeDataList.value.filter(
+            (item) => {
+                return item.table_name === activeAdministrativeArea.value?.table_name;
+            }
+        );
+        const clickedFeatureGID = e.features[0].properties.gid;
         if (activeDataFeaturesList.length > 0) {
-            const clickedItemFeature: Feature = activeDataFeaturesList[0].data.features.filter((feature)=>{ return feature.properties!.gid === clickedFeatureGID })[0]
-            const clickedItem: AdministrativeFeature = { data:{ ...clickedItemFeature }, id:activeAdministrativeArea.value!.id, name:activeAdministrativeArea.value!.name, table_name:activeAdministrativeArea.value!.table_name }
-            console.log("from click event: ", clickedItem)
-            let alreadySelected = false
+            const clickedItemFeature: Feature =
+        activeDataFeaturesList[0].data.features.filter((feature) => {
+            return feature.properties!.gid === clickedFeatureGID;
+        })[0];
+            const clickedItem: AdministrativeFeature = {
+                data: { ...clickedItemFeature },
+                id: activeAdministrativeArea.value!.id,
+                name: activeAdministrativeArea.value!.name,
+                table_name: activeAdministrativeArea.value!.table_name,
+            };
+            console.log("from click event: ", clickedItem);
+            let alreadySelected = false;
             selectedAdministrativeFeaturesList.value.forEach((feature) => {
-                if ((feature.table_name === clickedItem.table_name) && (feature.data.properties!.gid === clickedItem.data.properties!.gid)){
-                    alreadySelected = true
+                if (
+                    feature.table_name === clickedItem.table_name &&
+          feature.data.properties!.gid === clickedItem.data.properties!.gid
+                ) {
+                    alreadySelected = true;
                 }
-            })
-            if (alreadySelected){
-                removeFromSelectedAdministrativeFeaturesList(clickedItem)
+            });
+            if (alreadySelected) {
+                removeFromSelectedAdministrativeFeaturesList(clickedItem);
             } else {
-                addToselectedAdministrativeFeaturesList(clickedItem)
+                addToselectedAdministrativeFeaturesList(clickedItem);
             }
         }
     }
     /**
-     * Creates the active administrative area layer on the map.
-     * @param data - The FeatureCollection representing the administrative area.
-     */
-    function createActiveAdminLayer(data: FeatureCollection): void{
+   * Creates the active administrative area layer on the map.
+   * @param data - The FeatureCollection representing the administrative area.
+   */
+    function createActiveAdminLayer(data: FeatureCollection): void {
         const layerStyle: Record<string, any> = {
-            paint:{
+            paint: {
                 "fill-color": "#BE9FCF",
                 "fill-opacity": 0.2,
-                "fill-outline-color": "#FF0000"
-            }
-        }
-        mapStore.addMapDataSource("geojson", "active-admin", false, undefined, undefined, data).then(()=>{
-            mapStore.addMapLayer("geojson", "active-admin", "fill", layerStyle, undefined, undefined, data, false, undefined, undefined, false).then(()=>{
-                mapStore.map.on("click", "active-admin", adminAreaClickEventHandler)
-            }).catch((error)=>{ console.error(error) })
-        }).catch((error)=>{ console.error(error) })
+                "fill-outline-color": "#FF0000",
+            },
+        };
+        mapStore
+            .addMapDataSource(
+                "geojson",
+                "active-admin",
+                false,
+                undefined,
+                undefined,
+                data
+            )
+            .then(() => {
+                mapStore
+                    .addMapLayer(
+                        "geojson",
+                        "active-admin",
+                        "fill",
+                        layerStyle,
+                        undefined,
+                        undefined,
+                        data,
+                        false,
+                        undefined,
+                        undefined,
+                        false
+                    )
+                    .then(() => {
+                        mapStore.map.on(
+                            "click",
+                            "active-admin",
+                            adminAreaClickEventHandler
+                        );
+                    })
+                    .catch((error) => {
+                        console.error(error);
+                    });
+            })
+            .catch((error) => {
+                console.error(error);
+            });
     }
     /**
-     * Updates the active administrative area layer on the map with new data.
-     * @param data - The FeatureCollection representing the updated administrative area.
-     */
-    function updateActiveAdminLayer(data: FeatureCollection): void{
-        // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
-        if (!(mapStore.map.getSource("active-admin"))){
-            createActiveAdminLayer(data)
+   * Updates the active administrative area layer on the map with new data.
+   * @param data - The FeatureCollection representing the updated administrative area.
+   */
+    function updateActiveAdminLayer(data: FeatureCollection): void {
+    // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
+        if (!mapStore.map.getSource("active-admin")) {
+            createActiveAdminLayer(data);
         }
-        mapStore.map.getSource("active-admin").setData(data)
+        mapStore.map.getSource("active-admin").setData(data);
     }
     /**
-     * Deletes the active administrative area layer from the map.
-     */
-    function deleteActiveAdminLayer(): void{
-        mapStore.map.removeLayer("active-admin")
-        mapStore.map.removeSource("active-admin")
-        mapStore.removeFromLayerList("active-admin")
-        mapStore.map.off("click", adminAreaClickEventHandler)
+   * Deletes the active administrative area layer from the map.
+   */
+    function deleteActiveAdminLayer(): void {
+        mapStore.map.removeLayer("active-admin");
+        mapStore.map.removeSource("active-admin");
+        mapStore.removeFromLayerList("active-admin");
+        mapStore.map.off("click", adminAreaClickEventHandler);
     }
 
     // reset selected areas
     /**
-     * Resets all selected areas, clearing administrative, drawn, and isochrone selections.
-     */
-    function resetSelectedAreas(): void{
-        removeSelectedIsochrone()
-        selectedAdministrativeFeaturesList.value = []
-        selectedDrawnGeometry.value = []
-        updateSelectedAreasTempLayer()
+   * Resets all selected areas, clearing administrative, drawn, and isochrone selections.
+   */
+    function resetSelectedAreas(): void {
+        removeSelectedIsochrone();
+        selectedAdministrativeFeaturesList.value = [];
+        selectedDrawnGeometry.value = [];
+        updateSelectedAreasTempLayer();
     }
     return {
         activeAdministrativeArea,
@@ -592,11 +910,11 @@ export const useGeometryStore = defineStore("geometry", () => {
         createActiveAdminLayer,
         updateActiveAdminLayer,
         deleteActiveAdminLayer,
-        resetSelectedAreas
-    }
-})
+        resetSelectedAreas,
+    };
+});
 
 /* eslint-disable */
 if (import.meta.hot) {
-    import.meta.hot.accept(acceptHMRUpdate(useGeometryStore, import.meta.hot))
+  import.meta.hot.accept(acceptHMRUpdate(useGeometryStore, import.meta.hot));
 }


### PR DESCRIPTION
Implement unique naming for drawn areas, inject names for administrative and isochrone areas, and add a symbol layer to display these labels on the map. Refactor isochrone metadata handling to ensure robust naming independent of store state.

# Implementation Walkthrough

This document outlines the changes made to implement feature names and the accompanying symbol layer.

## 1. Store Updates (`src/store/ligfinder/geometry.ts`)

### Symbol Layer

Added a new symbol layer `selectedAreasLabels` linked to the existing `selectedAreasTempLayer` source. This layer displays the `name` property of features using a haloed text style for visibility.

### Unique Naming for Drawn Areas

Modified `addToSelectedDrawnGeometry` to implement a collision-avoidance strategy. It checks existing names in the list and increments a counter (e.g., "Drawn Area 1", "Drawn Area 2") to ensure uniqueness before adding the feature.

### robust Isochrone Naming

Refactored the isochrone creation flow:

1.  **`getIsochrone`**: Now injects the request parameters (`time` and `mode`) directly into the returned GeoJSON feature properties.
2.  **`addToSelectedIsochrone`**: Uses these injected properties to generate the descriptive name (e.g., "Isochrone (walk - 10 min)"). This fixes a bug where relying on the volatile `travelTime` state caused incorrect labels (e.g., "0 min") if the state was reset before naming occurred.

## 2. Component Updates

### `src/components/ligfinder/LIGGeometryDrawnAreas.vue`

Updated the chip display loop to use `feature.properties.name` instead of a generic index-based label. This ensures the UI matches the map label.

### `src/components/ligfinder/LIGGeometryIsochroneAreas.vue`

Updated the chip display to use `_isochrone.properties.name`, providing users with immediate context about the isochrone mode and duration.
